### PR TITLE
fix StringCompositor to support underscore and numbers

### DIFF
--- a/metagen-api/src/main/java/io/virtdata/templates/StringCompositor.java
+++ b/metagen-api/src/main/java/io/virtdata/templates/StringCompositor.java
@@ -20,9 +20,8 @@ import java.util.regex.Pattern;
 public class StringCompositor implements ValuesBinder<StringCompositor, String> {
 
 //    private static Pattern tokenPattern = Pattern.compile("(?<!\\\\)\\{([^}]*)\\}(.*?)?",Pattern.DOTALL);
-    private static Pattern tokenPattern = Pattern.compile("(?<section>(?<literal>[^{}]+)?(?<anchor>\\{(?<token>[a-zA-Z.-]+)?\\})?)");
+    private static Pattern tokenPattern = Pattern.compile("(?<section>(?<literal>[^{}]+)?(?<anchor>\\{(?<token>[a-zA-Z0-9-_.]+)?\\})?)");
     private String[] templateSegments;
-    private int buffersize=0;
 
     /**
      * Create a string template which has positional tokens, in "{}" form.
@@ -41,7 +40,6 @@ public class StringCompositor implements ValuesBinder<StringCompositor, String> 
     private String[] parseTemplate(String template) {
         Matcher matcher = tokenPattern.matcher(template);
         List<String> sections = new ArrayList<>();
-        int previous=0;
         int counter=0;
         while (matcher.find()) {
             String literal = matcher.group("literal");
@@ -100,9 +98,9 @@ public class StringCompositor implements ValuesBinder<StringCompositor, String> 
 //
     @Override
     public String bindValues(StringCompositor context, Bindings bindings, long cycle) {
-        StringBuilder sb = new StringBuilder(buffersize);
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < templateSegments.length; i++) {
-            if ((i&1)==0) { // even?
+            if (i % 2 == 0) {
                 sb.append(templateSegments[i]);
             } else {
                 String key = templateSegments[i];

--- a/metagen-lib-basics/src/main/java/io/virtdata/basicsmappers/from_long/to_string/DirectoryLines.java
+++ b/metagen-lib-basics/src/main/java/io/virtdata/basicsmappers/from_long/to_string/DirectoryLines.java
@@ -66,7 +66,7 @@ public class DirectoryLines implements LongFunction<String> {
             throw new RuntimeException(e);
         }
         logger.debug("File reader: " + fileList.toString() + " in path: " + Paths.get(basepath).getFileName());
-
+        fileList.paths.sort(Path::compareTo);
         return fileList.paths;
     }
 

--- a/metagen-lib-basics/src/test/java/io/virtdata/basicsmappers/from_long/to_string/DirectoryLinesTest.java
+++ b/metagen-lib-basics/src/test/java/io/virtdata/basicsmappers/from_long/to_string/DirectoryLinesTest.java
@@ -10,7 +10,6 @@ public class DirectoryLinesTest {
     @Test
     public void testResourceDirectory() {
         DirectoryLines directoryLines = new DirectoryLines("./src/test/resources/static-do-not-change", ".+txt");
-        String s;
         assertThat(directoryLines.apply(0)).isEqualTo("data1.txt-line1");
         assertThat(directoryLines.apply(0)).isEqualTo("data1.txt-line2");
         assertThat(directoryLines.apply(0)).isEqualTo("data1.txt-line3");

--- a/metagen-userlibs/src/test/java/io/virtdata/core/StringCompositorTest.java
+++ b/metagen-userlibs/src/test/java/io/virtdata/core/StringCompositorTest.java
@@ -14,10 +14,12 @@ public class StringCompositorTest {
 
     @BeforeClass
     public void setupTemplate() {
-
         BindingsTemplate bindingsTemplate = new BindingsTemplate(AllDataMapperLibraries.get());
         bindingsTemplate.addFieldBinding("ident","Identity()");
         bindingsTemplate.addFieldBinding("mod5", "Mod(5)");
+        bindingsTemplate.addFieldBinding("mod-5", "Mod(5)");
+        bindingsTemplate.addFieldBinding("5_mod_5", "Mod(5)");
+        bindingsTemplate.addFieldBinding(".mod5", "Mod(5)");
         this.template = bindingsTemplate;
         this.bindings = bindingsTemplate.resolveBindings();
     }
@@ -29,4 +31,18 @@ public class StringCompositorTest {
         assertThat(s).isEqualTo("A0C");
     }
 
+    @Test
+    public void testBindValuesSpecialChars() {
+        StringCompositor c = new StringCompositor("A{mod-5}C");
+        String s = c.bindValues(c, bindings, 6L);
+        assertThat(s).isEqualTo("A1C");
+
+        c = new StringCompositor("A{5_mod_5}C");
+        s = c.bindValues(c, bindings, 7L);
+        assertThat(s).isEqualTo("A2C");
+
+        c = new StringCompositor("A{.mod5}C");
+        s = c.bindValues(c, bindings, 8L);
+        assertThat(s).isEqualTo("A3C");
+    }
 }


### PR DESCRIPTION
maybe this fixes #41 ? i am not sure, but it was a bug either way i guess?

i was wondering if there is a special reason why `StringCompositor` and `StringCompositorTest` are in different maven modules?

local test with `mvn clean package`:
```
[INFO] Reactor Summary:
[INFO] 
[INFO] project-defaults ................................... SUCCESS [  0.806 s]
[INFO] metagen-api ........................................ SUCCESS [  7.036 s]
[INFO] metagen-lib-random ................................. SUCCESS [  3.322 s]
[INFO] metagen-lib-basics ................................. SUCCESS [  6.766 s]
[INFO] metagen-lib-composer ............................... SUCCESS [  4.322 s]
[INFO] metagen-lib-curves ................................. SUCCESS [  6.723 s]
[INFO] metagen-userlibs ................................... SUCCESS [ 11.188 s]
[INFO] metagen-lang ....................................... SUCCESS [  6.963 s]
[INFO] metagen-lib-realer ................................. SUCCESS [  2.491 s]
[INFO] metagen ............................................ SUCCESS [  0.172 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 50.732 s
[INFO] Finished at: 2017-11-09T10:28:33+01:00
[INFO] Final Memory: 115M/1584M
[INFO] ------------------------------------------------------------------------
```

the DirectoryLinesTest failed for me like this previously:
```
[ERROR] Tests run: 43, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.773 s <<< FAILURE! - in TestSuite
[ERROR] testResourceDirectory(io.virtdata.basicsmappers.from_long.to_string.DirectoryLinesTest)  Time elapsed: 0.019 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <"data2.txt-line1">
to be equal to:
 <"data1.txt-line1">
but was not.
	at io.virtdata.basicsmappers.from_long.to_string.DirectoryLinesTest.testResourceDirectory(DirectoryLinesTest.java:14)
```
i assume it is because the order of files found depends on the jvm version or platform, thus i added sorting to make it deterministic?