### PR TITLE
bugfix: ComposerLibrary enforces that first function accepts Long input

### DIFF
--- a/metagen-lib-composer/src/main/java/io/virtdata/libraryimpl/ComposerLibrary.java
+++ b/metagen-lib-composer/src/main/java/io/virtdata/libraryimpl/ComposerLibrary.java
@@ -115,6 +115,7 @@ public class ComposerLibrary implements DataMapperLibrary {
             throw new RuntimeException("There is no initial function which accepts a long input. Function chain, after type filtering: \n" +
                     summarize(funcs));
         }
+        removeNonLongFunctions(funcs.getFirst());
 
         ValueType resultType = multiSpecData.getResultType().orElseThrow(() -> new RuntimeException("missing result type specifier"));
         List<ResolvedFunction> flattenedFuncs = optimizePath(funcs, resultType);
@@ -131,6 +132,23 @@ public class ComposerLibrary implements DataMapperLibrary {
 
         ResolvedFunction composedFunction = assembly.getResolvedFunction(isThreadSafe);
         return Optional.of(composedFunction);
+    }
+
+    private void removeNonLongFunctions(List<ResolvedFunction> funcs)
+    {
+        List<ResolvedFunction> toRemove = new LinkedList<>();
+        for (ResolvedFunction func : funcs)
+        {
+            if (func.getFunctionType().getInputValueType() != ValueType.LONG)
+            {
+                toRemove.add(func);
+            }
+        }
+        if (toRemove.size() > 0 && toRemove.size() == funcs.size())
+        {
+            throw new RuntimeException("removeNonLongFunctions would remove all functions: " + funcs);
+        }
+        funcs.removeAll(toRemove);
     }
 
     private String summarize(List<ResolvedFunction> funcs) {

--- a/metagen-userlibs/src/test/java/io/virtdata/ComposerLibraryTest.java
+++ b/metagen-userlibs/src/test/java/io/virtdata/ComposerLibraryTest.java
@@ -161,6 +161,50 @@ public class ComposerLibraryTest {
         Object i = intMapper.get().get(23L);
         assertThat(i).isNotNull();
         assertThat(i.getClass()).isEqualTo(Integer.class);
+    }
 
+    private static Object assertMapper(String def, long cycle)
+    {
+        Optional<DataMapper<Object>> mapper = AllDataMapperLibraries.get().getDataMapper(def);
+        assertThat(mapper).isPresent();
+        Object o = mapper.get().get(cycle);
+        assertThat(o).isNotNull();
+        return o;
+    }
+
+    private static void assertInteger(Object o, int expected)
+    {
+        assertThat(o.getClass()).isEqualTo(Integer.class);
+        assertThat(o).isEqualTo(expected);
+    }
+
+    @Test
+    public void testChainedHashRanges()
+    {
+        final int initialCycle = 0;
+        final int intermediateCycle = 39;
+        final int finalCycle = 81;
+
+        Object intermediateValue = assertMapper("compose HashRange(0,100) -> int", initialCycle);
+        assertInteger(intermediateValue, intermediateCycle);
+
+        Object finalValue = assertMapper("compose HashRange(0,100) -> int", intermediateCycle);
+        assertInteger(finalValue, finalCycle);
+
+        Object finalChainedValue = assertMapper("compose HashRange(0,100); HashRange(0,100) -> int", initialCycle);
+        assertInteger(finalChainedValue, finalCycle);
+    }
+
+    @Test
+    public void testLeadingIdentityDoesNotImpactTypes()
+    {
+        final int initialCycle = 0;
+        final int finalCycle = 167;
+
+        Object o1 = assertMapper("compose HashRange(0,1000); HashRange(0,1000) -> int", initialCycle);
+        assertInteger(o1, finalCycle);
+
+        Object o2 = assertMapper("compose Identity(); HashRange(0,1000); HashRange(0,1000) -> int", initialCycle);
+        assertInteger(o2, finalCycle);
     }
 }


### PR DESCRIPTION
this is probably fixing #40
all added tests fail on master currently.

previously:
```
compose Identity(); HashRange(0,1000); HashRange(0,1000) -> int
```
became
```
fn:io.virtdata.basicsmappers.from_long.to_long.Identity, type:long_long|fn:io.virtdata.basicsmappers.from_long.to_long.HashRange, type:long_long|fn:io.virtdata.basicsmappers.from_long.to_int.HashRange, type:long_int
```

even though:
```
compose HashRange(0,1000); HashRange(0,1000) -> int
```
became
```
fn:io.virtdata.basicsmappers.unary_int.HashRange, type:int_int|fn:io.virtdata.basicsmappers.unary_int.HashRange, type:int_int
```

since `ComposerLibrary` already fails if the first position candidate functions do not accept input of type `Long` i changed it that only functions with that input type are considered candidates and can be "type-optimized" further down the line.

tested locally by `mvn clean package`:
```
[INFO] Reactor Summary:
[INFO] 
[INFO] project-defaults ................................... SUCCESS [  0.787 s]
[INFO] metagen-api ........................................ SUCCESS [  6.910 s]
[INFO] metagen-lib-random ................................. SUCCESS [  3.208 s]
[INFO] metagen-lib-basics ................................. SUCCESS [  6.259 s]
[INFO] metagen-lib-composer ............................... SUCCESS [  4.063 s]
[INFO] metagen-lib-curves ................................. SUCCESS [  6.514 s]
[INFO] metagen-userlibs ................................... SUCCESS [ 10.801 s]
[INFO] metagen-lang ....................................... SUCCESS [  6.842 s]
[INFO] metagen-lib-realer ................................. SUCCESS [  2.422 s]
[INFO] metagen ............................................ SUCCESS [  0.173 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 48.820 s
[INFO] Finished at: 2017-11-09T11:02:02+01:00
[INFO] Final Memory: 127M/1608M
[INFO] ------------------------------------------------------------------------
```