### PR TITLE
add AlphaNumericString

### DIFF
--- a/metagen-lib-basics/src/main/java/io/virtdata/basicsmappers/from_long/to_string/AlphaNumericString.java
+++ b/metagen-lib-basics/src/main/java/io/virtdata/basicsmappers/from_long/to_string/AlphaNumericString.java
@@ -1,0 +1,45 @@
+package io.virtdata.basicsmappers.from_long.to_string;
+
+import java.util.function.LongFunction;
+
+import io.virtdata.api.ThreadSafeMapper;
+import io.virtdata.basicsmappers.from_long.to_long.Hash;
+
+@ThreadSafeMapper
+public class AlphaNumericString implements LongFunction<String>
+{
+    private static final String AVAILABLE_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private final ThreadLocal<StringBuilder> threadStringBuilder = ThreadLocal.withInitial(StringBuilder::new);
+    private final Hash hash = new Hash();
+    private final int length;
+
+    public AlphaNumericString(int length)
+    {
+        if (length < 0)
+        {
+            throw new RuntimeException("AlphaNumericString must have length >= 0");
+        }
+        this.length = length;
+    }
+
+    @Override
+    public String apply(long operand)
+    {
+        long hashValue = operand;
+        StringBuilder sb = threadStringBuilder.get();
+        sb.setLength(0);
+        for (int i = 0; i < length; i++)
+        {
+            hashValue = hash.applyAsLong(hashValue);
+            int randomPos = (int) (hashValue % AVAILABLE_CHARS.length());
+            sb.append(AVAILABLE_CHARS.charAt(randomPos));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AlphaNumericString(length=" + length + ")";
+    }
+}

--- a/metagen-lib-basics/src/test/java/io/virtdata/long_string/AlphaNumericStringTest.java
+++ b/metagen-lib-basics/src/test/java/io/virtdata/long_string/AlphaNumericStringTest.java
@@ -1,0 +1,43 @@
+package io.virtdata.long_string;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.virtdata.basicsmappers.from_long.to_string.AlphaNumericString;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AlphaNumericStringTest
+{
+    @Test
+    public void testAlphaNumericStringZeroLength()
+    {
+        AlphaNumericString alphaNumeric = new AlphaNumericString(0);
+        for (long cycle = 0; cycle < 5; cycle++)
+        {
+            String value = alphaNumeric.apply(cycle);
+            assertThat(value).isEqualTo("");
+        }
+    }
+
+    @Test
+    public void testAlphaNumericStringBasic()
+    {
+        AlphaNumericString alphaNumeric = new AlphaNumericString(20);
+        Set<String> seen = new HashSet<>();
+        for (long cycle = 0; cycle < 5000; cycle++)
+        {
+            String value = alphaNumeric.apply(cycle);
+            assertThat(value.length()).isEqualTo(20);
+            assertThat(seen).doesNotContain(value);
+            seen.add(value);
+        }
+        for (long cycle = 0; cycle < 5000; cycle++)
+        {
+            String value = alphaNumeric.apply(cycle);
+            assertThat(value.length()).isEqualTo(20);
+            assertThat(seen).contains(value);
+        }
+    }
+}


### PR DESCRIPTION
i ran into:
```
22:59:11.459 [DC1_write:971] ERROR i.e.activityimpl.motor.CoreMotor - Error in core motor loop
:java.lang.IllegalArgumentException: Can only format numbers between 0-999999999: 1600000486
java.lang.IllegalArgumentException: Can only format numbers between 0-999999999: 1600000486
        at uk.ydubey.formatter.numtoword.NumberFormatter.format(NumberFormatter.java:11)
        at io.virtdata.basicsmappers.from_long.to_string.NumberNameToString.apply(NumberNameTo
String.java:36)
```

and found no easy way to generate a random string of a certain length with the existing functions (and without needing an extra data file?)